### PR TITLE
Fix typos

### DIFF
--- a/Pure-Data/fc_client-help.pd
+++ b/Pure-Data/fc_client-help.pd
@@ -9,5 +9,5 @@
 #X text 15 311 more :;
 #X obj 65 312 helplink FCPD;
 #X text 10 200 no inlet;
-#X text 10 240 1 outlet : last max process time (usefull to calibrate
+#X text 10 240 1 outlet : last max process time (useful to calibrate
 animation);

--- a/Pure-Data/fc_client.pd
+++ b/Pure-Data/fc_client.pd
@@ -15,7 +15,7 @@
 14 #e0e0e0 #404040 0;
 #X obj 644 275 cnv 15 551 261 empty empty Wait\ for\ callback\ (synchronize\ FC\ and\ PD)
 20 12 0 14 #e0e0e0 #404040 0;
-#X obj 790 130 cnv 15 217 101 empty empty Incomming\ message 20 12
+#X obj 790 130 cnv 15 217 101 empty empty Incoming\ message 20 12
 0 14 #e0e0e0 #404040 0;
 #X obj 1140 40 cnv 15 240 150 empty empty Callback 20 12 0 14 #e0e0e0
 #404040 0;

--- a/Pure-Data/fc_vector-help.pd
+++ b/Pure-Data/fc_vector-help.pd
@@ -9,5 +9,5 @@
 #X text 10 40 Create a FreeCAD-compatible vector message from coordinates
 ;
 #X obj 370 10 fc_vector;
-#X text 10 80 3 arguments to intialize X \, Y and Z;
+#X text 10 80 3 arguments to initialize X \, Y and Z;
 #X text 10 120 1st inlet : X or bang to output the last vector;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## FreeCAD/PureData connection framework
 
-FCPD is a set of [FreeCAD](https://github.com/FreeCAD/FreeCAD) python macros and [Pure-Data](https://github.com/pure-data/pure-data) (aka PD) patches to link the two softwares.
+FCPD is a set of [FreeCAD](https://github.com/FreeCAD/FreeCAD) python macros and [Pure-Data](https://github.com/pure-data/pure-data) (aka PD) patches to link the two software.
 
 This repository is no more maintained, please use [FCPDWorkbench](https://github.com/FlachyJoe/FCPDWorkbench).
 
@@ -37,8 +37,8 @@ See [Sample/PdAccessObjectProperties.FCMacro](Sample/PdAccessObjectProperties.FC
 
 * Import the pdserver module in your macro
 * instantiate a `pdserver.PureDataServer` object with address and port to listen to as constructor arguments
-* set the default message handler i.e. function which take the incomming message as argument and return a stringable value to give back to Pure-Data
-* with message handler registration system you can use different function depending of the first word of the incomming message. Simply call `PureDataServer.register_message_handler([first_word], function_to_call)`
+* set the default message handler i.e. function which take the incoming message as argument and return a stringable value to give back to Pure-Data
+* with message handler registration system you can use different function depending of the first word of the incoming message. Simply call `PureDataServer.register_message_handler([first_word], function_to_call)`
 * run the server with `pureDataServer.run()`
 
 ### On Pure-Data side
@@ -59,7 +59,7 @@ PD objects are documented. Access help via Right mouse button(RMB) > Help
 
 Pure-Data messages are text only so the FreeCAD objects have to be converted to and from string to be processed with Pure-Data.
 
-The PureDataServer object automaticaly remove non-conform characters of the callback message i.e. `,` and `=` are converted to space and `';()\[\]{}"` are removed. In this way the `Base.Vector` python object whose string representation is `Vector(0.0,0.0,0.0)` can be a return value of a message handler and converted to `Vector 0.0 0.0 0.0` PD message.
+The PureDataServer object automatically remove non-conform characters of the callback message i.e. `,` and `=` are converted to space and `';()\[\]{}"` are removed. In this way the `Base.Vector` python object whose string representation is `Vector(0.0,0.0,0.0)` can be a return value of a message handler and converted to `Vector 0.0 0.0 0.0` PD message.
 
 ## Feedback
 

--- a/Sample/animate.pd
+++ b/Sample/animate.pd
@@ -32,7 +32,7 @@
 #X text 442 595 new Pos;
 #X text 396 630 update Placement;
 #X text 321 663 set new Placement to object;
-#X text 119 425 go to 2*X0 in 1sec \; (\$1 is incomming float);
+#X text 119 425 go to 2*X0 in 1sec \; (\$1 is incoming float);
 #X text 613 279 Rotation is not used;
 #X text 128 498 rampe object \; initialized with 50ms step;
 #X obj 425 398 pipe 1000;


### PR DESCRIPTION
Found via `codespell -q 3`